### PR TITLE
ocppのmessage uidを露出 & conf送信を別で行えるように切り出し

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plugoinc/ts-ocpp",
-  "version": "0.0.3",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@plugoinc/ts-ocpp",
-      "version": "0.0.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@plugoinc/ts-ocpp",
   "description": "OCPP (Open Charge Point Protocol) implemented in Typescript",
-  "version": "0.0.3",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/plugoinc/ts-ocpp",
@@ -41,5 +41,7 @@
     "ts-jest": "^26.5.4",
     "typescript": "^4.2.3"
   },
-  "files": ["dist/**/*"]
+  "files": [
+    "dist/**/*"
+  ]
 }

--- a/src/cs/index.ts
+++ b/src/cs/index.ts
@@ -320,7 +320,7 @@ export default class CentralSystem {
       socket,
       // @ts-ignore, TS is not good with dependent typing, it doesn't realize that the function
       // returns OCPP v1.6 responses when the request is a OCPP v1.6 request
-      (request, validationError) => this.cpHandler(request, { ...metadata, validationError }),
+      (request, validationError, messageId) => this.cpHandler(request, { ...metadata, validationError }, messageId),
       chargePointActions,
       centralSystemActions,
       this.options.rejectInvalidRequests,

--- a/src/cs/index.ts
+++ b/src/cs/index.ts
@@ -8,13 +8,13 @@ import { ChargePointAction, chargePointActions } from '../messages/cp';
 import { Connection, OCPPJMessage, SUPPORTED_PROTOCOLS } from '../ws';
 import { CentralSystemAction, centralSystemActions } from '../messages/cs';
 import { OCPPRequestError, ValidationError } from '../errors';
-import { EitherAsync, Left } from 'purify-ts';
+import { EitherAsync, Left, Right } from 'purify-ts';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as soap from 'soap';
 import * as uuid from 'uuid';
 import { IServices, ISoapServiceMethod } from 'soap';
-import { OCPPVersion } from '../types';
+import { OCPPVersion, OCPPVersionV16 } from '../types';
 import SOAPConnection from '../soap/connection';
 import Debug from "debug";
 const debug = Debug("ts-ocpp:cs");
@@ -189,6 +189,28 @@ export default class CentralSystem {
         }
       }
     })
+  }
+
+  sendResponseWithId<V extends OCPPVersionV16,T extends ChargePointAction>(
+    args: { chargePointId: string, messageId: string, response: Response<T, V> }
+  ): EitherAsync<OCPPRequestError, void> {
+    return EitherAsync.fromPromise(async () => {
+      const { chargePointId, messageId, response } = args;
+      const cpDebug = debug.extend(chargePointId);
+      if (!chargePointId) return Left(new OCPPRequestError('charge point id was not provided'));
+
+      const [connection] = this.connections[chargePointId] ?? [];
+      if (!connection) {
+        cpDebug('no connection found, cannot send deferred response');
+        return Left(new OCPPRequestError('there is no connection to this charge point'));
+      }
+
+      await connection.sendResponseWithId(
+        messageId,
+        response as Response<ChargePointAction, 'v1.6-json'>
+      );
+      return Right(undefined);
+    });
   }
 
   /** @internal */

--- a/src/cs/index.ts
+++ b/src/cs/index.ts
@@ -205,10 +205,15 @@ export default class CentralSystem {
         return Left(new OCPPRequestError('there is no connection to this charge point'));
       }
 
-      await connection.sendResponseWithId(
-        messageId,
-        response as Response<ChargePointAction, 'v1.6-json'>
-      );
+      try {
+        await connection.sendResponseWithId(
+          messageId,
+          response as Response<ChargePointAction, 'v1.6-json'>
+        );
+      } catch (error: any) {
+        cpDebug('failed to send deferred response: %s', error?.message ?? String(error));
+        return Left(new OCPPRequestError(error?.message ?? 'failed to send deferred response'));
+      }
       return Right(undefined);
     });
   }

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -42,5 +42,8 @@ type Result<T> = Promise<T> | T;
  * @category Handler
  */
 export type RequestHandler<T extends ActionName<V>, Metadata = undefined, V extends OCPPVersion = OCPPVersion> =
-  (request: Request<T, V>, extra: Metadata) => Result<Response<T, V>>;
-
+  /**
+ * Returning `false` signals that the handler will respond later (no CALLRESULT is sent automatically).
+   * `messageId` is the id from the incoming message, useful when sending a deferred response.
+   */
+  (request: Request<T, V>, extra: Metadata, messageId?: string) => Result<Response<T, V> | false>;

--- a/src/ws/connection.ts
+++ b/src/ws/connection.ts
@@ -5,7 +5,7 @@ import { ActionName, Request, RequestHandler, Response } from '../messages';
 import { OCPPApplicationError, OCPPRequestError, OCPPRequestTimedOutError, ValidationError } from '../errors/index';
 import { validateMessageRequest } from '../messages/validation';
 import * as uuid from 'uuid';
-import { EitherAsync, Left, Right, Just, Nothing, MaybeAsync } from 'purify-ts';
+import { EitherAsync, Left, Right, Just, Nothing, MaybeAsync, Either } from 'purify-ts';
 import Debug from "debug";
 const debug = Debug("ts-ocpp:ws");
 
@@ -82,6 +82,17 @@ export default class Connection<ReqAction extends ActionName<'v1.6-json'>> {
     this.socket.close();
   }
 
+  public async sendResponseWithId(id: string, response: Response<ReqAction, 'v1.6-json'>): Promise<void> {
+    const { action: _action, ocppVersion: _ocppVersion, ...payload } = response as Response<ReqAction, 'v1.6-json'> & { ocppVersion?: string };
+    const message: OCPPJMessage = {
+      id,
+      type: MessageType.CALLRESULT,
+      payload,
+    };
+    this.handlers?.onSendResponse(message);
+    await this.sendOCPPMessage(message);
+  }
+
   private async sendOCPPMessage(message: OCPPJMessage): Promise<void> {
     return new Promise((resolve, reject) => {
       this.socket.send(stringifyOCPPMessage(message), err => {
@@ -113,15 +124,21 @@ export default class Connection<ReqAction extends ActionName<'v1.6-json'>> {
               })
               .chain(async ({ request, validationError }) => {
                 try {
-                  const response = await this.requestHandler(request, validationError);
+                  const response = await this.requestHandler(request, validationError, message.id);
                   return Right(response);
                 } catch (error: any) {
                   return Left(new OCPPApplicationError('on handling chargepoint request').wrap(error));
                 }
               });
 
+          if (response.isRight() && response.extract() === false) {
+            debug(`request handler for ${message.action} returned false, skipping automatic response for id ${message.id}`);
+            return Nothing;
+          }
+
           const formattedResponse =
-            response
+          // falseは上記で早期リターンしているため、EitherのRightから除外する
+            (response as Either<ValidationError | OCPPApplicationError, Response<ReqAction, "v1.6-json">>)
               // merge both failure and success to a OCPP-J message
               .either<OCPPJMessage>(fail => ({
                 id: message.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * OCPP v1.6-json の遅延レスポンス機能に対応しました。リクエストハンドラーで後続のレスポンス送信が可能になります。

* **Chores**
  * パッケージバージョンを 0.0.3 から 0.2.0 に更新しました。
  * パッケージ設定フォーマットを整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->